### PR TITLE
Adding run method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ echo $bench->getMemoryPeak(false, '%.3f%s'); // 152B or 90.152Kb or 15.234Mb
 
 // Returns the memory usage at the end mark
 echo $bench->getMemoryUsage(); // 152B or 90.00Kb or 15.23Mb
+
+// Runs `Ubench::start()` and `Ubench::end()` around a callable
+// Accepts a callable as the first parameter.  Any additional parameters will be passed to the callable.
+$result = $bench->run(function ($x) {
+    return $x;
+}, 1);
+echo $bench->getTime();
 ```
 
 License

--- a/src/Ubench.php
+++ b/src/Ubench.php
@@ -92,6 +92,27 @@ class Ubench
     }
 
     /**
+     * Wraps a callable with start() and end() calls
+     *
+     * Additional arguments passed to this method will be passed to
+     * the callable.
+     *
+     * @param callable $callable
+     * @return mixed
+     */
+    public function run(callable $callable)
+    {
+        $arguments = func_get_args();
+        array_shift($arguments);
+
+        $this->start();
+        $result = call_user_func_array($callable, $arguments);
+        $this->end();
+
+        return $result;
+    }
+
+    /**
      * Returns a human readable memory size
      *
      * @param   int    $size

--- a/tests/UbenchTest.php
+++ b/tests/UbenchTest.php
@@ -74,4 +74,26 @@ class UbenchTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('integer', $bench->getMemoryPeak(true));
         $this->assertRegExp('/^[0-9]+Mb/', $bench->getMemoryPeak(false, '%d%s'));
     }
+
+    public function testCallableWithoutArguments()
+    {
+        $bench = new Ubench();
+        $result = $bench->run(function () { return true; });
+
+        $this->assertTrue($result);
+        $this->assertNotNull($bench->getTime());
+        $this->assertNotNull($bench->getMemoryUsage());
+        $this->assertNotNull($bench->getMemoryPeak());
+    }
+
+    public function testCallableWithArguments()
+    {
+        $bench = new Ubench();
+        $result = $bench->run(function ($one, $two) { return $one + $two; }, 1, 2);
+
+        $this->assertEquals(3, $result);
+        $this->assertNotNull($bench->getTime());
+        $this->assertNotNull($bench->getMemoryUsage());
+        $this->assertNotNull($bench->getMemoryPeak());
+    }
 }


### PR DESCRIPTION
The run() method wraps a callable with start() and end() calls and returns the
result of the callable.  Any arguments passed into the method after the
callable will be passed to the callable.

Signed-off-by: Nate Brunette <n@tebru.net>